### PR TITLE
DEVOPS-184833: Update vulnerabilities + clean up docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,23 @@
 
 -------------------------
 
-## 2.2.2.2
+## [Unreleased]
 
-- 2021-01-22
-	- REL-515458 - Removed check for Admin Audits for the Data Grid Test
+### Added
+
+- Added NuGet packages for running tests via Visual Studio 2022/dotnet (#16)
+- Created separate `SqlInstance` test constant to account for differences in server instance name across DevVM versions (#16)
+
+### Changed
+
+- Expanded README &amp; updated formatting of CHANGELOG to follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) (#16)
+
+### Security
+
+- Newtonsoft.Json version bumped to 13.0.3 (#16)
+
+## [2.2.2.2] - 2021-01-22
+
+### Removed
+
+- Removed check for Admin Audits for the Data Grid Test (#9)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # relativity-smoke-test-app 
+
+> **WARNING**
+>
+> This repository has been archived. It has not been updated for several years and uses a now-defunct API (Relativity Services API).
+
+This is a test suite &amp; RAP used to check the correctness of the Relativity DevVM.
+
+There is no formal process for running these tests or building the associated RAP (not sure if any such public instructions exist), but this suite may be useful so long as we still provide DevVM releases.
+
+## Building
+
+The projects are built in Visual Studio. They have been most recently tested &amp; run using Visual Studio 2022.
+
+## Running Tests
+
+All the appropriate NuGet packages should be added for running tests directly from Visual Studio 2022, so you should not need to install any extensions.
+
+1. Create a local DevVM &amp; ensure it is licensed. You may want to create a checkpoint.
+1. Upload the latest copy of the test RAP in the [Application](./Application) folder to the DevVM's Application Library.
+1. Modify the following constants in [TestConstants.cs](./SourceCode/SmokeTest.Tests/TestConstants.cs) as appropriate:
+    1. `ServerName`: IP address of your DevVM.
+    1. `SqlInstance`: Full SQL Server instance name on your DevVM. The default should be correct for any DevVMs created since March 2022, but for earlier ones use the appropriate instance name rather than `EDDSINSTANCE001`.
+    1. `WorkspaceArtifactId`: Artifact ID of the workspace used to create objects. Must already exist on the DevVM.
+1. Run the tests from the Test Explorer in Visual Studio, or use `dotnet`:
+
+       > dotnet test .\SourceCode\SmokeTest.sln
+
+## Maintainers
+
+This repository is maintained by the Developer Environments team, which also owns the Relativity DevVM.
+
+You may create a GitHub Issue in this repository to file a defect or request a feature, or open a PR.

--- a/SourceCode/SmokeTest.Tests/SmokeTest.Tests.csproj
+++ b/SourceCode/SmokeTest.Tests/SmokeTest.Tests.csproj
@@ -43,8 +43,8 @@
     <Reference Include="kCura.Relativity.Client, Version=11.0.162.34, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Relativity.Rsapi.11.0.162.34\lib\net462\kCura.Relativity.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
@@ -58,14 +58,13 @@
     <Reference Include="Relativity.Audit.Services.Interface, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Relativity.Audit.Services.SDK.17.0.1\lib\net462\Relativity.Audit.Services.Interface.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.DocumentViewer.Services.Interfaces, Version=9.5.370.136, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\SmokeTest\bin\Debug\Relativity.DocumentViewer.Services.Interfaces.dll</HintPath>
+    <Reference Include="Relativity.DocumentViewer.Services.Interfaces">
+      <HintPath>..\Assemblies\Relativity.DocumentViewer.Services.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="Relativity.Imaging.Services.Interfaces">
       <HintPath>..\Assemblies\Relativity.Imaging.Services.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Kepler, Version=1.0.1.627, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Relativity.Kepler">
       <HintPath>..\packages\Relativity.ObjectManager.11.0.162.34\lib\net462\Relativity.Kepler.dll</HintPath>
     </Reference>
     <Reference Include="Relativity.Logging, Version=2019.5.1.0, Culture=neutral, processorArchitecture=MSIL">
@@ -89,7 +88,7 @@
     <Reference Include="Relativity.Services.Interfaces.Private">
       <HintPath>..\Assemblies\Relativity.Services.Interfaces.Private.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Services.ServiceProxy, Version=1.0.1.627, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Relativity.Services.ServiceProxy">
       <HintPath>..\packages\Relativity.ObjectManager.11.0.162.34\lib\net462\Relativity.Services.ServiceProxy.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/SourceCode/SmokeTest.Tests/SmokeTest.Tests.csproj
+++ b/SourceCode/SmokeTest.Tests/SmokeTest.Tests.csproj
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.13.3\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" />
+  <Import Project="..\packages\Microsoft.NET.Test.Sdk.17.5.0\build\net462\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.17.5.0\build\net462\Microsoft.NET.Test.Sdk.props')" />
+  <Import Project="..\packages\Microsoft.CodeCoverage.17.5.0\build\netstandard2.0\Microsoft.CodeCoverage.props" Condition="Exists('..\packages\Microsoft.CodeCoverage.17.5.0\build\netstandard2.0\Microsoft.CodeCoverage.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.4.4.2\build\net462\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.4.4.2\build\net462\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +16,8 @@
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,11 +49,14 @@
     <Reference Include="kCura.Relativity.Client, Version=11.0.162.34, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Relativity.Rsapi.11.0.162.34\lib\net462\kCura.Relativity.Client.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.CodeCoverage.Shim, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeCoverage.17.5.0\lib\net462\Microsoft.VisualStudio.CodeCoverage.Shim.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.13.3.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.13.3\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Relativity, Version=11.0.110.89, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Relativity.Other.12.0.1\lib\net462\Relativity.dll</HintPath>
@@ -144,6 +153,19 @@
     <Content Include="LICENSE.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.4.4.2\build\net462\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.4.4.2\build\net462\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeCoverage.17.5.0\build\netstandard2.0\Microsoft.CodeCoverage.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeCoverage.17.5.0\build\netstandard2.0\Microsoft.CodeCoverage.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeCoverage.17.5.0\build\netstandard2.0\Microsoft.CodeCoverage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeCoverage.17.5.0\build\netstandard2.0\Microsoft.CodeCoverage.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.17.5.0\build\net462\Microsoft.NET.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.17.5.0\build\net462\Microsoft.NET.Test.Sdk.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.17.5.0\build\net462\Microsoft.NET.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.17.5.0\build\net462\Microsoft.NET.Test.Sdk.targets'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.3\build\NUnit.props'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.CodeCoverage.17.5.0\build\netstandard2.0\Microsoft.CodeCoverage.targets" Condition="Exists('..\packages\Microsoft.CodeCoverage.17.5.0\build\netstandard2.0\Microsoft.CodeCoverage.targets')" />
+  <Import Project="..\packages\Microsoft.NET.Test.Sdk.17.5.0\build\net462\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.17.5.0\build\net462\Microsoft.NET.Test.Sdk.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/SourceCode/SmokeTest.Tests/SqlHelper.cs
+++ b/SourceCode/SmokeTest.Tests/SqlHelper.cs
@@ -9,7 +9,7 @@ namespace SmokeTest.Tests
 		public static int GetIdentifierFieldArtifactId(int workspaceArtifactId)
 		{
 			int documentIdentifierFieldArtifactId;
-			string connectionstring = $"Data Source={TestConstants.ServerName}; Initial Catalog=EDDS{workspaceArtifactId}; User Id={TestConstants.SqlLogin}; Password={TestConstants.SqlPassword};";
+			string connectionstring = $"Data Source={TestConstants.SqlInstance}; Initial Catalog=EDDS{workspaceArtifactId}; User Id={TestConstants.SqlLogin}; Password={TestConstants.SqlPassword};";
 			SqlConnection sqlConnection = new SqlConnection
 			{
 				ConnectionString = connectionstring

--- a/SourceCode/SmokeTest.Tests/TestConstants.cs
+++ b/SourceCode/SmokeTest.Tests/TestConstants.cs
@@ -5,8 +5,9 @@ namespace SmokeTest.Tests
 {
 	public class TestConstants
 	{
-		public static readonly string ServerName = "172.25.138.163";
-		public static readonly int WorkspaceArtifactId = 1017518;
+		public static readonly string ServerName = "172.30.171.244";
+		public static readonly string SqlInstance = $"{ServerName}\\EDDSINSTANCE001";
+		public static readonly int WorkspaceArtifactId = 1019403;
 		public static readonly string RelativityLogin = "relativity.admin@relativity.com";
 		public static readonly string RelativityPassword = "Test1234!";
 		public static readonly string SqlLogin = "eddsdbo";

--- a/SourceCode/SmokeTest.Tests/app.config
+++ b/SourceCode/SmokeTest.Tests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/SourceCode/SmokeTest.Tests/packages.config
+++ b/SourceCode/SmokeTest.Tests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="BCrypt.Net-Core" version="1.6.0" targetFramework="net462" />
   <package id="BCrypt-Official" version="0.1.109" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
   <package id="NUnit" version="3.7.1" targetFramework="net462" />
   <package id="Relativity.Api" version="12.0.1" targetFramework="net462" />
   <package id="Relativity.Audit.Services.SDK" version="17.0.1" targetFramework="net462" />

--- a/SourceCode/SmokeTest.Tests/packages.config
+++ b/SourceCode/SmokeTest.Tests/packages.config
@@ -2,8 +2,11 @@
 <packages>
   <package id="BCrypt.Net-Core" version="1.6.0" targetFramework="net462" />
   <package id="BCrypt-Official" version="0.1.109" targetFramework="net462" />
+  <package id="Microsoft.CodeCoverage" version="17.5.0" targetFramework="net462" />
+  <package id="Microsoft.NET.Test.Sdk" version="17.5.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
-  <package id="NUnit" version="3.7.1" targetFramework="net462" />
+  <package id="NUnit" version="3.13.3" targetFramework="net462" />
+  <package id="NUnit3TestAdapter" version="4.4.2" targetFramework="net462" />
   <package id="Relativity.Api" version="12.0.1" targetFramework="net462" />
   <package id="Relativity.Audit.Services.SDK" version="17.0.1" targetFramework="net462" />
   <package id="Relativity.Logging" version="2019.5.1" targetFramework="net462" />

--- a/SourceCode/SmokeTest/SmokeTest.csproj
+++ b/SourceCode/SmokeTest/SmokeTest.csproj
@@ -49,8 +49,8 @@
     <Reference Include="kCura.Relativity.Client, Version=11.0.162.34, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Relativity.Rsapi.11.0.162.34\lib\net462\kCura.Relativity.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Relativity, Version=11.0.110.89, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Relativity.Other.12.0.1\lib\net462\Relativity.dll</HintPath>

--- a/SourceCode/SmokeTest/app.config
+++ b/SourceCode/SmokeTest/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/SourceCode/SmokeTest/packages.config
+++ b/SourceCode/SmokeTest/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="BCrypt.Net-Core" version="1.6.0" targetFramework="net462" />
   <package id="BCrypt-Official" version="0.1.109" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
   <package id="Relativity.Agent" version="11.0.162.34" targetFramework="net462" />
   <package id="Relativity.Api" version="12.0.1" targetFramework="net462" />
   <package id="Relativity.Audit.Services.SDK" version="17.0.1" targetFramework="net462" />


### PR DESCRIPTION
Did a bit of work to get Snyk off our back before archiving this repository. Updated everything to build & run in VS 2022, but since the tests all use the Services API (now deprecated) this can't really be used for modern versions of DevVM.